### PR TITLE
Add support for using FAISS index in the vector DB

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,8 @@
 numpy==1.*
 torch
 datasets
-torch
 pybioclip
 chromadb
 tqdm
 webdataset
-faiss-gpu
+# faiss-gpu

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ pybioclip
 chromadb
 tqdm
 webdataset
+faiss-gpu

--- a/src/bioclip_vector_db/storage/storage_factory.py
+++ b/src/bioclip_vector_db/storage/storage_factory.py
@@ -16,6 +16,8 @@ class HfDatasetType(enum.Enum):
 
 class StorageEnum(enum.Enum):
     CHROMADB = 1
+    FAISS_IVF = 2
+
 
 def get_storage(storage_type: StorageEnum, dataset_type: HfDatasetType, **kwargs) -> StorageInterface:
     """
@@ -28,5 +30,14 @@ def get_storage(storage_type: StorageEnum, dataset_type: HfDatasetType, **kwargs
         return chroma.init(dataset_type.name, 
                            collection_dir=kwargs["collection_dir"],
                            metadata={"hnsw:space": "ip", "hnsw:search_ef": 10})
+    
+    if storage_type == StorageEnum.FAISS_IVF:
+        if "collection_dir" not in kwargs:
+            raise ValueError("Faiss cannot be initialized without collection_dir.")
+        faiss_ivf = storage_impl.FaissIvf()
+        return faiss_ivf.init(dataset_type.name, 
+                              collection_dir=kwargs["collection_dir"],
+                              dimensions=512,
+                              nlist=10)
 
     raise ValueError(f"Invalid storage type: {storage_type}")

--- a/src/bioclip_vector_db/storage/storage_impl.py
+++ b/src/bioclip_vector_db/storage/storage_impl.py
@@ -142,3 +142,6 @@ class FaissIvf(StorageInterface):
         # once trained, add all the training data back into the db.
         for id, embedding, metadata in zip(self._train_ids, self._train_embeddings, self._train_metadatas):
             self._add_embedding_to_index(id, embedding, metadata)
+
+    def flush(self):
+        faiss.write_index(self._index, f"{self._collection_dir}/faiss.index")

--- a/src/bioclip_vector_db/storage/storage_impl.py
+++ b/src/bioclip_vector_db/storage/storage_impl.py
@@ -1,5 +1,6 @@
 import chromadb
 import logging
+import faiss
 
 from .storage_interface import StorageInterface
 from typing import List, Dict
@@ -57,3 +58,42 @@ class Chroma(StorageInterface):
             metadata=self._metadata,
             collection_dir=self._collection_dir,
         )
+
+
+class FaissIvf(StorageInterface):
+    """Faiss index with inverted file index. Requires training to use."""
+
+    def init(self, name: str, **kwargs):
+        if "collection_dir" not in kwargs:
+            raise ValueError("Faiss cannot be initialized without collection_dir.")
+        if "dimensions" not in kwargs:
+            raise ValueError("Faiss cannot be initialized without dimensions.")
+        if "factory_string" not in kwargs:
+            raise ValueError("Faiss cannot be initialized without factory_string.")
+
+        self._collection_dir = kwargs["collection_dir"]
+        self._dimensions = kwargs["dimensions"]
+        self._factory_string = kwargs["factory_string"]
+
+        self._index = faiss.index_factory(self._dimensions, self._factory_string)
+
+        logger.info(
+            f"Initializing Faiss client with the factory string: {self._factory_string}."
+        )
+
+    def add_embedding(self, id: str, embedding: List[float], metadata: Dict[str, str]):
+        pass
+
+    def batch_add_embeddings(
+        self,
+        ids: List[str],
+        embeddings: List[List[float]],
+        metadatas: List[Dict[str, str]],
+    ):
+        pass
+
+    def query(self, id: str):
+        pass
+
+    def reset(self, force=False):
+        pass

--- a/src/bioclip_vector_db/storage/storage_impl.py
+++ b/src/bioclip_vector_db/storage/storage_impl.py
@@ -97,7 +97,7 @@ class FaissIvf(StorageInterface):
         return self
     
     def _add_embedding_to_index(self, id: str, embedding: List[float], metadata: Dict[str, str]):
-        self._index.add(embedding)
+        self._index.add(np.array(embedding))
         self._metadata_store[self._index.ntotal] = {"id": id, "metadata": metadata} 
 
     def add_embedding(self, id: str, embedding: List[float], metadata: Dict[str, str]):

--- a/src/bioclip_vector_db/storage/storage_impl.py
+++ b/src/bioclip_vector_db/storage/storage_impl.py
@@ -97,7 +97,7 @@ class FaissIvf(StorageInterface):
         return self
     
     def _add_embedding_to_index(self, id: str, embedding: List[float], metadata: Dict[str, str]):
-        self._index.add(np.array(embedding))
+        self._index.add(np.array([embedding]).astype("float32"))
         self._metadata_store[self._index.ntotal] = {"id": id, "metadata": metadata} 
 
     def add_embedding(self, id: str, embedding: List[float], metadata: Dict[str, str]):

--- a/src/bioclip_vector_db/storage/storage_impl.py
+++ b/src/bioclip_vector_db/storage/storage_impl.py
@@ -74,7 +74,7 @@ class FaissIvf(StorageInterface):
         else:
             self._nlist = kwargs["nlist"]
 
-        self._train_set_size = 1000 # * self._nlist
+        self._train_set_size = 50 * self._nlist
 
         self._collection_dir = kwargs["collection_dir"]
         self._dimensions = kwargs["dimensions"]

--- a/src/bioclip_vector_db/storage/storage_impl.py
+++ b/src/bioclip_vector_db/storage/storage_impl.py
@@ -63,7 +63,8 @@ class Chroma(StorageInterface):
 
 class FaissIvf(StorageInterface):
     """Faiss index with inverted file index. Requires training to use."""
-
+    # TODO: Write index in shards. 
+    
     def init(self, name: str, **kwargs):
         if "collection_dir" not in kwargs:
             raise ValueError("Faiss cannot be initialized without collection_dir.")

--- a/src/bioclip_vector_db/storage/storage_interface.py
+++ b/src/bioclip_vector_db/storage/storage_interface.py
@@ -84,3 +84,12 @@ class StorageInterface(ABC):
         Resets the database to its initial state.
         """
         pass
+
+    def flush(self):
+        """
+        Performs the flush operation, if required.
+
+        Returns True if the flush operation was successful, False otherwise.
+        """
+        pass
+

--- a/src/bioclip_vector_db/vector_db.py
+++ b/src/bioclip_vector_db/vector_db.py
@@ -240,7 +240,7 @@ def main():
 
     # Currently only CHROMA backend is supported so hardcoding is fine.
     storage_obj = storage_factory.get_storage(
-        storage_type=storage_factory.StorageEnum.CHROMADB,
+        storage_type=storage_factory.StorageEnum.FAISS_IVF,
         dataset_type=dataset,
         collection_dir=output_dir,
     )

--- a/src/bioclip_vector_db/vector_db.py
+++ b/src/bioclip_vector_db/vector_db.py
@@ -68,6 +68,7 @@ class BioclipVectorDatabase:
             logger.info(f"Loading dataset from local disk: {local_dataset}")
 
             # iterating through the dataset will fetch {batch_size} records at once.
+            # todo: sreejith - shuffle the dataset to support train indexes when appropriate.
             self._dataset = wds.DataPipeline(
                 wds.SimpleShardList(local_dataset),
                 wds.tarfile_to_samples(),

--- a/src/bioclip_vector_db/vector_db.py
+++ b/src/bioclip_vector_db/vector_db.py
@@ -182,6 +182,7 @@ class BioclipVectorDatabase:
             self._load_database_local()
         else:
             self._load_database_web()
+        self._storage.flush()
 
 
 def main():


### PR DESCRIPTION
Support for FAISS indexing logic with tree of life dataset. 

- stores the index in a single file. 
- skips the storage of all metadata since in memory storage of all metadata would likely be another memory bottleneck. 