### PR TITLE
Add logic for leader based neighborhood search and a cache mode

### DIFF
--- a/src/bioclip_vector_db/client/nearest_neighbor_client.py
+++ b/src/bioclip_vector_db/client/nearest_neighbor_client.py
@@ -51,8 +51,11 @@ class NearestNeighborClient:
         }
         for url in self._server_urls:
             search_url = f"{url}/search"
-            result = self._post_request(search_url, search_payload)
-            results.append({"server": url, "response": result})
+            try:
+                result = self._post_request(search_url, search_payload)
+                results.append({"server": url, "response": result})
+            except Exception as e:
+                logger.error(f"Search for {url} failed: {e}")
 
         return self._merge_results(results)
 


### PR DESCRIPTION
incredible performance gains when using a cache 

no cache
```
python -m src.bioclip_vector_db.query.neighborhood_server --index_dir /Users/sreejithnoopur/codebase/faiss_index_large --index_file_prefix=local_ --partitions 1-999 --port 5003 --leader_index=leader.index

0.0018 seconds
```

with cache 
```
python -m src.bioclip_vector_db.query.neighborhood_server --index_dir /Users/sreejithnoopur/codebase/faiss_index_large --index_file_prefix=local_ --partitions 1-999 --port 5004 --leader_index=leader.index --use_cache

0.0037 seconds - 100% cache miss
0.0012 seconds - 100% cache hits
```